### PR TITLE
Removed deprecated CMake functions and removed unused link

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -15,4 +15,3 @@ set(SOURCES
 add_executable(App ${SOURCES})
 target_link_libraries(App glfw)
 target_link_libraries(App glad)
-target_link_libraries(App glm)

--- a/App/Source/Shader.cpp
+++ b/App/Source/Shader.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <vector>
 
 #include <glad/gl.h>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,20 +10,13 @@ set(CMAKE_CXX_STANDARD 20)
 #
 
 # GLFW
-find_package(glfw3 3.4 QUIET)
-if (NOT glfw3_FOUND)
-    FetchContent_Declare(
-            glfw3
-            DOWNLOAD_EXTRACT_TIMESTAMP OFF
-            URL https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip
-    )
-    FetchContent_GetProperties(glfw3)
-    if (NOT glfw3_POPULATED)
-        set(FETCHCONTENT_QUIET NO)
-        FetchContent_Populate(glfw3)
-        add_subdirectory(${glfw3_SOURCE_DIR} ${glfw3_BINARY_DIR})
-    endif()
-endif()
+FetchContent_Declare(
+    glfw
+    GIT_REPOSITORY https://github.com/glfw/glfw.git
+    GIT_TAG 3.4
+    FIND_PACKAGE_ARGS NAMES glfw3
+)
+FetchContent_MakeAvailable(glfw)
 
 # OpenGL
 find_package(OpenGL REQUIRED)
@@ -31,36 +24,22 @@ find_package(OpenGL REQUIRED)
 # GLAD
 FetchContent_Declare(
     glad
-    DOWNLOAD_EXTRACT_TIMESTAMP OFF
-    URL https://github.com/Dav1dde/glad/archive/refs/tags/v2.0.8.zip
+    GIT_REPOSITORY https://github.com/Dav1dde/glad.git
+    GIT_TAG v2.0.8
 )
+FetchContent_MakeAvailable(glad)
 
-FetchContent_GetProperties(glad)
-if(NOT glad_POPULATED)
-    set(FETCHCONTENT_QUIET NO)
-    FetchContent_MakeAvailable(glad)
-
-    add_subdirectory("${glad_SOURCE_DIR}/cmake" glad_cmake)
-    glad_add_library(glad REPRODUCIBLE EXCLUDE_FROM_ALL LOADER API gl:core=4.6)
-endif()
-set_target_properties(glad PROPERTIES FOLDER "Dependencies")
+add_subdirectory("${glad_SOURCE_DIR}/cmake" glad_cmake)
+glad_add_library(glad REPRODUCIBLE EXCLUDE_FROM_ALL LOADER API gl:core=4.6)
 
 # GLM
-find_package(glm 1.0.1 QUIET)
-if (NOT glm_FOUND)
-    FetchContent_Declare(
-            glm
-            DOWNLOAD_EXTRACT_TIMESTAMP OFF
-            URL https://github.com/g-truc/glm/archive/refs/tags/1.0.1.zip
-    )
-    FetchContent_GetProperties(glm)
-    if (NOT glm_POPULATED)
-        set(FETCHCONTENT_QUIET NO)
-        FetchContent_Populate(glm)
-        add_subdirectory(${glm_SOURCE_DIR} ${glm_BINARY_DIR})
-    endif()
-endif()
-set_target_properties(glm PROPERTIES FOLDER "Dependencies")
+FetchContent_Declare(
+        glm
+        GIT_REPOSITORY https://github.com/g-truc/glm.git
+        GIT_TAG 1.0.1
+        FIND_PACKAGE_ARGS
+)
+FetchContent_MakeAvailable(glm)
 
 #
 # Projects


### PR DESCRIPTION
This PR removes deprecated CMake functions as well as removing the call to link the glm library which is never compiled, only included as a header. There also was a compilation error because of not including the vector std lib.

As part of updating the CMake function, the `find_package` calls are also redundant since they can be done as part of the `FetchContent_Declare` call. When adding `FIND_PACKAGE_ARGS` to the call, it will attempt to find it first using `find_package`.

This ensures this repository stays relevant and compilable out of the box instead of having to fix the CMakeLists file in the future. On most modern CMake versions, the current version already spits out warnings while configuring.

